### PR TITLE
Fixed audio not being written when video was ahead and lint warnings

### DIFF
--- a/src/encoders/audio_encoder.rs
+++ b/src/encoders/audio_encoder.rs
@@ -45,6 +45,7 @@ impl AudioEncoder {
             Self::boost_with_rms(raw_frame.get_samples_mut())?;
             self.leftover_data.extend(raw_frame.get_samples());
 
+            self.audio_buffer.insert_capture_time(raw_frame.timestamp);
             // Send chunked frames to encoder
             while self.leftover_data.len() >= frame_size {
                 let frame_samples: Vec<f32> = self.leftover_data.drain(..frame_size).collect();
@@ -59,7 +60,6 @@ impl AudioEncoder {
                 frame.set_pts(Some(self.next_pts));
                 frame.set_rate(encoder.rate());
 
-                self.audio_buffer.insert_capture_time(raw_frame.timestamp);
                 encoder.send_frame(&frame)?;
 
                 // Try and get a frame back from encoder

--- a/src/pw_capture/video_stream.rs
+++ b/src/pw_capture/video_stream.rs
@@ -21,12 +21,10 @@ use crate::{RawVideoFrame, Terminate};
 
 pub struct VideoCapture;
 
-#[derive(Clone, Copy)]
-#[derive(Default)]
+#[derive(Clone, Copy, Default)]
 struct UserData {
     video_format: spa::param::video::VideoInfoRaw,
 }
-
 
 impl VideoCapture {
     #[allow(clippy::too_many_arguments)]
@@ -146,11 +144,17 @@ impl VideoCapture {
                         // send frame data to encoder
                         let data = &mut datas[0];
                         if let Some(frame) = data.data() {
-                            if let Err(frame) = ringbuf_producer.try_push(RawVideoFrame {
-                                bytes: frame.to_vec(),
-                                timestamp: time_us,
-                            }) {
-                                error!("Error sending video frame: {:?}. Ring buf full?", frame);
+                            if ringbuf_producer
+                                .try_push(RawVideoFrame {
+                                    bytes: frame.to_vec(),
+                                    timestamp: time_us,
+                                })
+                                .is_err()
+                            {
+                                error!(
+                                    "Error sending video frame at: {:?}. Ring buf full?",
+                                    time_us
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
Audio iterator was not being incremented on skipped timestamps so audio was never written :( 