### PR TITLE
Decoupled video buffer from video encoder for more extensibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,9 +1004,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libdbus-sys"

--- a/src/encoders/buffer.rs
+++ b/src/encoders/buffer.rs
@@ -35,7 +35,7 @@ impl VideoFrameData {
 /// The buffer is ordered by decoding timestamp (DTS) and maintains complete GOPs (groups of pictures),
 /// ensuring that no partial GOPs are kept when trimming for ease of muxing and playback.
 #[derive(Clone)]
-pub struct VideoBuffer {
+pub struct ShadowCaptureVideoBuffer {
     frames: BTreeMap<i64, VideoFrameData>,
 
     /// Maximum duration (in seconds) that the buffer should retain.
@@ -47,7 +47,7 @@ pub struct VideoBuffer {
     key_frame_keys: Vec<i64>,
 }
 
-impl VideoBuffer {
+impl ShadowCaptureVideoBuffer {
     /// Creates a new `FrameBuffer` with a specified maximum duration.
     ///
     /// # Arguments

--- a/src/encoders/buffer_tests.rs
+++ b/src/encoders/buffer_tests.rs
@@ -17,7 +17,7 @@ fn test_video_buffer_no_trim() {
         VideoFrameData::new(vec![3], true, 6),
     ];
 
-    let mut buffer = VideoBuffer::new(10);
+    let mut buffer = ShadowCaptureVideoBuffer::new(10);
 
     buffer.insert(1, dummy_frames[0].clone());
     buffer.insert(2, dummy_frames[1].clone());
@@ -42,7 +42,7 @@ fn test_video_buffer_no_trim() {
 
 #[test]
 fn test_video_buffer_trimming() {
-    let mut buffer = VideoBuffer::new(10);
+    let mut buffer = ShadowCaptureVideoBuffer::new(10);
 
     let dummy_frames = [
         VideoFrameData::new(vec![1], true, 0),

--- a/src/encoders/vaapi_encoder.rs
+++ b/src/encoders/vaapi_encoder.rs
@@ -13,10 +13,14 @@ use ffmpeg_next::{
     Rational,
 };
 use log::error;
+use ringbuf::{
+    traits::{Producer, Split},
+    HeapCons, HeapProd, HeapRb,
+};
 
 use super::{
-    buffer::{VideoBuffer, VideoFrameData},
-    video_encoder::{VideoEncoder, GOP_SIZE, ONE_MICROS},
+    buffer::VideoFrameData,
+    video_encoder::{VideoEncoder, GOP_SIZE},
 };
 
 thread_local! {
@@ -25,32 +29,35 @@ thread_local! {
 
 pub struct VaapiEncoder {
     encoder: Option<ffmpeg::codec::encoder::Video>,
-    video_buffer: VideoBuffer,
     width: u32,
     height: u32,
     encoder_name: String,
     quality: QualityPreset,
+    encoded_frame_recv: Option<HeapCons<(i64, VideoFrameData)>>,
+    encoded_frame_sender: Option<HeapProd<(i64, VideoFrameData)>>,
 }
 
 impl VideoEncoder for VaapiEncoder {
-    fn new(
-        width: u32,
-        height: u32,
-        max_buffer_seconds: u32,
-        quality: QualityPreset,
-    ) -> anyhow::Result<Self>
+    fn new(width: u32, height: u32, quality: QualityPreset) -> anyhow::Result<Self>
     where
         Self: Sized,
     {
+        // TODO: Should create a child thread that polls the encoder and does the buffer logic
+        // doing it all at once takes too long
+
         let encoder_name = "h264_vaapi";
         let encoder = Self::create_encoder(width, height, encoder_name, &quality)?;
+        let video_ring_buffer = HeapRb::<(i64, VideoFrameData)>::new(120);
+        let (video_ring_sender, video_ring_receiver) = video_ring_buffer.split();
+
         Ok(Self {
             encoder: Some(encoder),
-            video_buffer: VideoBuffer::new(max_buffer_seconds as usize * ONE_MICROS),
             width,
             height,
             encoder_name: encoder_name.to_string(),
             quality,
+            encoded_frame_recv: Some(video_ring_receiver),
+            encoded_frame_sender: Some(video_ring_sender),
         })
     }
 
@@ -126,14 +133,21 @@ impl VideoEncoder for VaapiEncoder {
                 let mut packet = ffmpeg::codec::packet::Packet::empty();
                 if encoder.receive_packet(&mut packet).is_ok() {
                     if let Some(data) = packet.data() {
-                        let frame_data = VideoFrameData::new(
-                            data.to_vec(),
-                            packet.is_key(),
-                            packet.pts().unwrap_or(0),
-                        );
-
-                        self.video_buffer
-                            .insert(packet.dts().unwrap_or(0), frame_data);
+                        if let Some(ref mut sender) = self.encoded_frame_sender {
+                            if sender
+                                .try_push((
+                                    packet.dts().unwrap_or(0),
+                                    VideoFrameData::new(
+                                        data.to_vec(),
+                                        packet.is_key(),
+                                        packet.pts().unwrap_or(0),
+                                    ),
+                                ))
+                                .is_err()
+                            {
+                                log::error!("Could not send encoded packet to the ringbuf");
+                            }
+                        }
                     };
                 }
             });
@@ -148,14 +162,21 @@ impl VideoEncoder for VaapiEncoder {
             let mut packet = ffmpeg::codec::packet::Packet::empty();
             while encoder.receive_packet(&mut packet).is_ok() {
                 if let Some(data) = packet.data() {
-                    let frame_data = VideoFrameData::new(
-                        data.to_vec(),
-                        packet.is_key(),
-                        packet.pts().unwrap_or(0),
-                    );
-
-                    self.video_buffer
-                        .insert(packet.dts().unwrap_or(0), frame_data);
+                    if let Some(ref mut sender) = self.encoded_frame_sender {
+                        if sender
+                            .try_push((
+                                packet.dts().unwrap_or(0),
+                                VideoFrameData::new(
+                                    data.to_vec(),
+                                    packet.is_key(),
+                                    packet.pts().unwrap_or(0),
+                                ),
+                            ))
+                            .is_err()
+                        {
+                            log::error!("Could not send encoded packet to the ringbuf");
+                        }
+                    }
                 };
                 packet = ffmpeg::codec::packet::Packet::empty();
             }
@@ -178,13 +199,12 @@ impl VideoEncoder for VaapiEncoder {
         &self.encoder
     }
 
-    fn get_buffer(&self) -> &VideoBuffer {
-        &self.video_buffer
+    fn drop_encoder(&mut self) {
+        self.encoder.take();
     }
 
-    fn drop_encoder(&mut self) {
-        self.video_buffer.reset();
-        self.encoder.take();
+    fn take_encoded_recv(&mut self) -> Option<HeapCons<(i64, VideoFrameData)>> {
+        self.encoded_frame_recv.take()
     }
 }
 

--- a/src/encoders/video_encoder.rs
+++ b/src/encoders/video_encoder.rs
@@ -1,26 +1,22 @@
 use anyhow::Result;
 use ffmpeg_next::{self as ffmpeg};
+use ringbuf::HeapCons;
 
 use crate::{application_config::QualityPreset, RawVideoFrame};
 
-use super::buffer::VideoBuffer;
+use super::buffer::VideoFrameData;
 
 pub const ONE_MICROS: usize = 1_000_000;
 pub const GOP_SIZE: u32 = 30;
 
-pub trait VideoEncoder {
-    fn new(
-        width: u32,
-        height: u32,
-        max_buffer_seconds: u32,
-        quality: QualityPreset,
-    ) -> Result<Self>
+pub trait VideoEncoder: Send {
+    fn new(width: u32, height: u32, quality: QualityPreset) -> Result<Self>
     where
         Self: Sized;
     fn process(&mut self, frame: &RawVideoFrame) -> Result<(), ffmpeg::Error>;
     fn drain(&mut self) -> Result<(), ffmpeg::Error>;
     fn reset(&mut self) -> Result<()>;
-    fn get_buffer(&self) -> &VideoBuffer;
     fn drop_encoder(&mut self);
     fn get_encoder(&self) -> &Option<ffmpeg::codec::encoder::Video>;
+    fn take_encoded_recv(&mut self) -> Option<HeapCons<(i64, VideoFrameData)>>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use anyhow::{Context, Error, Result};
 use application_config::load_or_create_config;
 use encoders::{
     audio_encoder::{AudioEncoderImpl, FfmpegAudioEncoder},
-    buffer::{AudioBuffer, VideoBuffer},
+    buffer::{AudioBuffer, ShadowCaptureVideoBuffer},
     video_encoder::ONE_MICROS,
 };
 use ffmpeg_next::{self as ffmpeg};
@@ -82,7 +82,7 @@ async fn main() -> Result<(), Error> {
 
 fn save_buffer(
     filename: &str,
-    video_buffer: &VideoBuffer,
+    video_buffer: &ShadowCaptureVideoBuffer,
     video_encoder: &ffmpeg::codec::encoder::Video,
     audio_buffer: &AudioBuffer,
     audio_encoder: &FfmpegAudioEncoder,


### PR DESCRIPTION
This optimization gives the following benefits:
1. Provides a framework where each mode can now implement their own worker for how to handle encoded frames allowing for extension into regular recording and anything else we could want.
2. Further optimizes the workflow, offloading buffer addition to its own worker thread which frees up time on the main encoder thread -- Previously this thread averaged ~20ms on the VAAPI encoder which was horrible; causing the queue to fill up as we weren't popping fast enough. Now it averages 15ms for VAAPI the vaapi workflow which is still cutting it close but I think its just related to all the overhead regarding scaling and such.
3. Renamed the VideoBuffer to better reflect its actual use case